### PR TITLE
Add Japanese localization and language toggle support

### DIFF
--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -2,21 +2,34 @@
 #   Create a section for each of your site's languages.
 #   Documentation: https://docs.hugoblox.com/reference/language/
 
-# Default language
 en:
   languageCode: en-us
-  # Uncomment for multi-lingual sites, and move English content into `en` sub-folder.
-  #contentDir: content/en
+  languageName: English
+  weight: 1
+  menu:
+    main:
+      - name: Bio
+        url: /
+        weight: 10
+      - name: Publications
+        url: /publication
+        weight: 11
+      - name: Presentations
+        url: /presentations
+        weight: 12
 
-# Uncomment the lines below to configure your website in a second language.
-#zh:
-#  languageCode: zh-Hans
-#  contentDir: content/zh
-#  title: Chinese website title...
-#  params:
-#    description: Site description in Chinese...
-#  menu:
-#    main:
-#      - name: 传
-#        url: '#about'
-#        weight: 1
+ja:
+  languageCode: ja
+  languageName: 日本語
+  weight: 2
+  menu:
+    main:
+      - name: 自己紹介
+        url: /
+        weight: 10
+      - name: 論文
+        url: /publication
+        weight: 11
+      - name: 発表
+        url: /presentations
+        weight: 12

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -34,6 +34,7 @@ header:
     fixed_to_top: true
     show_search: true
     show_theme_chooser: true
+    show_language: true
     logo:
       text: "Atsutomo Yara (屋良 淳朝)"
 

--- a/content/_index.ja.md
+++ b/content/_index.ja.md
@@ -1,0 +1,46 @@
+---
+# Leave the homepage title empty to use the site title
+title: "Atsutomo Yara (屋良 淳朝)"
+date: 2022-10-24
+type: landing
+
+design:
+  spacing: "6rem"
+
+sections:
+  - block: resume-biography-3
+    content:
+      username: admin
+      text: ""
+    design:
+      css_class: dark
+      background:
+        color: black
+        image:
+          filename: stacked-peaks.svg
+          filters:
+            brightness: 1.0
+          size: cover
+          position: center
+          parallax: false
+  - block: collection
+    content:
+      title: 最新の論文
+      text: ""
+      filters:
+        folders:
+          - publication
+        exclude_featured: false
+    design:
+      view: citation
+  - block: resume-experience
+    content:
+      username: admin
+    design:
+      date_format: '2006年1月'
+      is_education_first: false
+  - block: resume-awards
+    content:
+      title: 受賞
+      username: admin
+---

--- a/content/authors/admin/_index.ja.md
+++ b/content/authors/admin/_index.ja.md
@@ -1,0 +1,60 @@
+---
+title: Atsutomo Yara (屋良 淳朝)
+first_name: Atsutomo (淳朝)
+last_name: Yara (屋良)
+status:
+  icon: 🀄️
+superuser: true
+highlight_name: true
+role: 博士後期課程学生
+organizations:
+  - name: 大阪大学
+    url: https://www.osaka-u.ac.jp/
+profiles:
+  - icon: at-symbol
+    url: 'mailto:a-yara@sigmath.es.osaka-u.ac.jp'
+    label: メール
+  - icon: brands/x
+    url: https://x.com/yaratsu99
+  - icon: brands/instagram
+    url: https://www.instagram.com/atsutomo1008
+  - icon: brands/github
+    url: https://github.com/yaratsu
+  - icon: brands/linkedin
+    url: https://www.linkedin.com/in/%E6%B7%B3%E6%9C%9D-%E5%B1%8B%E8%89%AF-690b38253/
+  - icon: academicons/google-scholar
+    url: https://scholar.google.com/citations?hl=en&user=O5vrjrEAAAAJ
+interests:
+  - 機械学習理論
+  - 数理統計
+  - 深層学習
+  - 統計的学習理論
+education:
+  - area: 修士（機械学習）
+    institution: 大阪大学
+    date_start: 2022-04-01
+    date_end: 2024-03-31
+  - area: 学士（情報科学）
+    institution: 大阪大学
+    date_start: 2018-04-01
+    date_end: 2022-03-31
+work:
+  - position: ティーチングアシスタント
+    company_name: 同志社大学
+    company_url: https://www.doshisha.ac.jp
+    company_logo: ''
+    date_start: 2025-04-01
+    date_end: ''
+awards:
+  - title: 2024年度統計関連学会連合大会 コンペティション部門発表賞
+    url: https://pub.confit.atlas.jp/en/event/jfssa2024
+    date: '2024-09-01'
+  - title: ISI Tokyo Memorial Award
+    date: '2025-09-01'
+---
+
+## 自己紹介
+
+屋良淳朝は大阪大学大学院基礎工学研究科の機械学習分野に在籍する博士後期課程学生です。
+指導教員は [寺田善一](https://sites.google.com/site/teradahp/home) 先生です。
+研究テーマは機械学習理論と数理統計です。

--- a/content/event/COMPSTAT2024.ja.md
+++ b/content/event/COMPSTAT2024.ja.md
@@ -1,0 +1,25 @@
+---
+title: "Nonparametric estimation of conditional class probabilities using deep neural networks"
+date: 2024-08-30
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "The 26th International Conference on Computational Statistics"
+event_url: "http://www.compstat2024.org/"
+
+location: "the University of Giessen, Germany"
+
+abstract: >
+  Consider the nonparametric logistic regression problem. In the logistic regression, the maximum likelihood estimator is usually considered, and the excess risk is the expectation of the Kullback-Leibler (KL) divergence between the true and estimated conditional class probabilities. However, in the nonparametric logistic regression, the KL divergence could diverge easily, and thus, the convergence of the excess risk is difficult to prove or does not hold. Several existing studies show the convergence of the KL divergence under strong assumptions. In most cases, the goal is to estimate the true conditional class probabilities. Thus, instead of analyzing the excess risk itself, it suffices to show the consistency of the maximum likelihood estimator in some suitable metric. Using a simple unified approach for analyzing the nonparametric maximum likelihood estimator (NPMLE), the convergence rates of the NPMLE are directly derived in the Hellinger distance under mild assumptions. Although the results are similar to the results in some existing studies, simple and more direct proofs are provided for these results. As an important application, the convergence rates of the NPMLE are derived with deep neural networks, and the derived rate is shown to achieve the minimax optimal rate nearly.
+
+# 分類用
+tags:
+  - International Conference
+
+# 発表資料リンク
+links:
+  - name: Slides
+    url: "/slides/COMPSTAT2024.pdf"
+---

--- a/content/event/IASC-ARS13.ja.md
+++ b/content/event/IASC-ARS13.ja.md
@@ -1,0 +1,23 @@
+---
+title: "Nonparametric Intensity Estimation in Covariate-Driven Poisson Processes Using Deep Learning"
+date: 2025-12-05
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "The 13th Conference of the IASC-ARS"
+event_url: "https://viasm.edu.vn/en/hdkh/iasc-ars-2025"
+
+location: "World Forum The Hague, The Hague, The Netherlands"
+
+abstract: >
+  We consider the nonparametric estimation problem of the intensity function for a Poisson process with covariates. Because the Kullback-Leibler divergence can diverge in nonparametric estimation, theoretical analysis of the nonparametric maximum likelihood estimator (NPMLE) is challenging. We use a simple unified approach to analyse the NPMLE and derive an oracle inequality in Hellinger distance between the true intensity function and the estimator. As an important application, we derive convergence rates for the NPMLE with deep neural networks. Our analysis shows that the NPMLE with deep learning can mitigate the curse of dimensionality when the true intensity has a composition structure and can automatically adapt to low-dimensional Riemannian manifold structures. Moreover, the derived convergence rates achieve nearly minimax-optimal rates under composition assumptions.
+
+# 分類用
+tags:
+  - International Conference
+
+# 発表資料リンク
+links: []
+---

--- a/content/event/ISIWSC65.ja.md
+++ b/content/event/ISIWSC65.ja.md
@@ -1,0 +1,23 @@
+---
+title: "On maximum likelihood estimation of intensity function for Poisson process with deep learning"
+date: 2025-10-07
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "65th ISI World Statistics Congress"
+event_url: "https://www.isi-next.org/conferences/isi-wsc2025/"
+
+location: "World Forum The Hague, The Hague, The Netherlands"
+
+abstract: >
+  A Poisson (point) process is a model that describes the random occurrence of events in space-time. Poisson processes have many useful applications because they can model various real-world problems (e.g., the frequency of taxi rides in a given area and the occurrence of earthquakes). The Poisson process can be characterized by an intensity function that describes the average rate of occurrence. Maximum likelihood estimation is often used to estimate the intensity function, and in the case of parametric models, it is known to satisfy nice theoretical properties (e.g., consistency and asymptotic normality) under some regularity conditions. However, for complex real-world problems such as the frequency of taxi rides, it is difficult to prepare a statistical model with a finite-dimensional parameter for the intensity function. In such situations, nonparametric estimation of the intensity function plays a key role. In theoretical studies on nonparametric estimation of intensity functions, many studies have focused on the estimators with explicit expressions. Although the estimators that do not have an explicit representation, such as those using deep learning, show strong performance in practical applications, the theoretical properties of such estimators are not well-studied. This talk focuses on the theoretical analysis of the nonparametric maximum likelihood estimation. Since the Kullback-Leibler (KL) divergence diverges easily in nonparametric estimation, the theoretical analysis for the nonparametric maximum likelihood estimator (NPMLE) is challenging. Therefore, we require strong and unrealistic assumptions for the theoretical analysis of NPMLE via the KL divergence. In real-world applications, though, convergence in the sense of KL divergence is unnecessary and sufficient to show consistency in an appropriate metric. In this study, we apply the simple unified technique to evaluate the Hellinger distance between the NPMLE and the true intensity function and derive the convergence rates of the NPMLE in the Hellinger distance instead of the KL divergence. We can derive the convergence rates under mild and realistic assumptions since the Hellinger distance is bounded whenever the estimated and true intensity functions are bounded. More precisely, We derive the Oracle inequality to evaluate the Hellinger distance between the NPMLE and the true intensity function. Furthermore, as an important application of the Oracle inequality, we derive the convergence rate of NPMLE with deep neural networks.
+
+# 分類用
+tags:
+  - International Conference
+
+# 発表資料リンク
+links: []
+---

--- a/content/event/JGSC8.ja.md
+++ b/content/event/JGSC8.ja.md
@@ -1,0 +1,24 @@
+---
+title: "Nonparametric Logistic Regression with Deep Neural Network"
+date: 2023-08-30
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "The 8th Japanese-German Symposium on Classification"
+event_url: "https://jgsc2023.ywstat.jp/"
+
+location: "Seminar Room, Frontier Research in Applied Sciences Building, Hokkaido University, Japan"
+
+abstract: 
+
+# 分類用
+tags:
+  - International Conference
+
+# 発表資料リンク
+links:
+  - name: Slides
+    url: "/slides/JGSC2023.pdf"
+---

--- a/content/event/JJSM2024.ja.md
+++ b/content/event/JJSM2024.ja.md
@@ -1,0 +1,22 @@
+---
+title: "深層学習と⽤いた Poisson 点過程の強度関数の最尤推定"
+date: 2024-09-03
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "2024年度統計関連学会連合大会"
+event_url: "https://pub.confit.atlas.jp/ja/event/jfssa2024"
+
+location: "東京理科大学　神楽坂キャンパス"
+
+abstract: 
+
+# 分類用
+tags:
+  - Domestic Conference
+
+# 発表資料リンク
+links:
+---

--- a/content/event/jsas2025n.ja.md
+++ b/content/event/jsas2025n.ja.md
@@ -1,0 +1,24 @@
+---
+title: "深層学習を⽤いたポアソン過程データに対するノンパラメトリック回帰"
+date: 2025-05-17
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "応用統計学会 2025年年会"
+event_url: "https://applstat.ywstat.jp/"
+
+location: "富山国際会議場"
+
+abstract: 
+
+# 分類用
+tags:
+  - Domestic Conference
+
+# 発表資料リンク
+links:
+  - name: Slides
+    url: "/slides/jscs38t.pdf"
+---

--- a/content/event/jscs38t.ja.md
+++ b/content/event/jscs38t.ja.md
@@ -1,0 +1,24 @@
+---
+title: "深層学習を⽤いた条件付き確率のノンパラメトリック最尤推定"
+date: 2024-05-24
+
+authors:
+  - admin
+  - Yoshikazu Terada
+
+event: "計算機統計学会 第38回大会"
+event_url: ""
+
+location: "やまぎん県民ホール"
+
+abstract: 
+
+# 分類用
+tags:
+  - Domestic Conference
+
+# 発表資料リンク
+links:
+  - name: Slides
+    url: "/slides/jscs38t.pdf"
+---

--- a/content/presentations/_index.ja.md
+++ b/content/presentations/_index.ja.md
@@ -1,0 +1,33 @@
+---
+title: "発表"
+type: landing
+
+sections:
+  - block: collection
+    id: intl
+    content:
+      title: "国際会議"
+      count: 0
+      filters:
+        folders:
+          - event
+        tag: "International Conference"
+      sort_by: Date
+      sort_ascending: false
+    design:
+      view: compact
+
+  - block: collection
+    id: domestic
+    content:
+      title: "国内会議"
+      count: 0
+      filters:
+        folders:
+          - event
+        tag: "Domestic Conference"
+      sort_by: Date
+      sort_ascending: false
+    design:
+      view: compact
+---

--- a/content/publication/_index.ja.md
+++ b/content/publication/_index.ja.md
@@ -1,0 +1,8 @@
+---
+title: 論文
+cms_exclude: true
+view: citation
+banner:
+  caption: ''
+  image: ''
+---

--- a/content/publication/terada-theory-2026/index.ja.md
+++ b/content/publication/terada-theory-2026/index.ja.md
@@ -1,0 +1,39 @@
+---
+title: A Theory of Nonparametric Covariance Function Estimation for Discretely Observed
+  Data
+authors:
+- Yoshikazu Terada
+- Atsutomo Yara
+date: '2026-03-01'
+publishDate: '2026-04-16T02:30:50.116791Z'
+publication_types:
+- manuscript
+publication: '*arXiv*'
+doi: 10.48550/arXiv.2603.23302
+abstract: We study nonparametric covariance function estimation for functional data
+  observed with noise at discrete locations on a ¥$d¥$-dimensional domain. Estimating
+  the covariance function from discretely observed data is a challenging nonparametric
+  problem, particularly in multidimensional settings, since the covariance function
+  is defined on a product domain and thus suffers from the curse of dimensionality.
+  This motivates the use of adaptive estimators, such as deep learning estimators.
+  However, existing theoretical results are largely limited to estimators with explicit
+  analytic representations, and the properties of general learning-based estimators
+  remain poorly understood. We establish an oracle inequality for a broad class of
+  learning-based estimators that applies to both sparse and dense observation regimes
+  in a unified manner, and derive convergence rates for deep learning estimators over
+  several classes of covariance functions. The resulting rates suggest that structural
+  adaptation can mitigate the curse of dimensionality, similarly to classical nonparametric
+  regression. We further compare the convergence rates of learning-based estimators
+  with several existing procedures. For a one-dimensional smoothness class, deep learning
+  estimators are suboptimal, whereas local linear smoothing estimators achieve a faster
+  rate. For a structured function class, however, deep learning estimators attain
+  the minimax rate up to polylogarithmic factors, whereas local linear smoothing estimators
+  are suboptimal. These results reveal a distinctive adaptivity-variance trade-off
+  in covariance function estimation.
+tags:
+- Mathematics - Statistics Theory
+- Statistics - Machine Learning
+links:
+- name: URL
+  url: http://arxiv.org/abs/2603.23302
+---

--- a/content/publication/yara-nonparametric-2026/index.ja.md
+++ b/content/publication/yara-nonparametric-2026/index.ja.md
@@ -1,0 +1,38 @@
+---
+title: Nonparametric logistic regression with deep learning
+authors:
+- Atsutomo Yara
+- Yoshikazu Terada
+date: '2026-05-01'
+publishDate: '2026-01-31T00:33:52.896652Z'
+publication_types:
+- article-journal
+publication: '*Bernoulli*'
+doi: 10.3150/25-BEJ1887
+abstract: Consider the nonparametric logistic regression problem. In the logistic
+  regression, we usually consider the maximum likelihood estimator, and the excess
+  risk is the expectation of the Kullback-Leibler (KL) divergence between the true
+  and estimated conditional class probabilities. However, in the nonparametric logistic
+  regression, the KL divergence could diverge easily, and thus, the convergence of
+  the excess risk is difficult to prove or does not hold. Several existing studies
+  show the convergence of the KL divergence under strong assumptions. In most cases,
+  our goal is to estimate the true conditional class probabilities. Thus, instead
+  of analyzing the excess risk itself, it suffices to show the consistency of the
+  maximum likelihood estimator in some suitable metric. In this paper, using a simple
+  unified approach for analyzing the nonparametric maximum likelihood estimator (NPMLE),
+  we directly derive convergence rates of the NPMLE in the Hellinger distance under
+  mild assumptions. Although our results are similar to the results in some existing
+  studies, we provide simple and more direct proofs for these results. As an important
+  application, we derive convergence rates of the NPMLE with fully connected deep
+  neural networks and show that the derived rate nearly achieves the minimax optimal
+  rate.
+tags:
+- classification
+- Conditional probability estimation
+- Deep neural networks
+- nonparametric estimation
+links:
+- name: URL
+  url: 
+    https://projecteuclid.org/journals/bernoulli/volume-32/issue-2/Nonparametric-logistic-regression-with-deep-learning/10.3150/25-BEJ1887.full
+---


### PR DESCRIPTION
### Motivation
- Enable a bilingual site (English + Japanese) so visitors can view content in either language. 
- Provide a language switcher in the navbar so users can toggle locales with a button/menu. 
- Ensure lists (events/publications) also present content when the site is viewed in Japanese by providing translations for entries.

### Description
- Added language configuration and per-language menus in `config/_default/languages.yaml` to register `en` and `ja` locales and language-specific main menus. 
- Enabled the navbar language switcher by setting `show_language: true` in `config/_default/params.yaml`. 
- Added Japanese content files for the homepage, author profile, presentations and publications index and created `.ja.md` translations for event and publication entries under `content/` so lists populate in Japanese mode (`content/_index.ja.md`, `content/authors/admin/_index.ja.md`, `content/presentations/_index.ja.md`, `content/publication/_index.ja.md`, `content/event/*.ja.md`, `content/publication/*/index.ja.md`).

### Testing
- Attempted to build with `hugo --minify`, but the command failed in this environment because `hugo` is not installed (build not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e998865ac8832cbb8566c2d377ac31)