### PR TITLE
Add Japanese i18n override for Experience label

### DIFF
--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,0 +1,2 @@
+- id: experience
+  translation: 職歴


### PR DESCRIPTION
### Motivation
- Ensure the site shows the `Experience` section label in Japanese as `職歴` on Japanese pages instead of the English word.

### Description
- Add `i18n/ja.yaml` containing the translation key `experience` mapped to `職歴` so Hugo i18n will render the label in Japanese.

### Testing
- Attempted to validate with `hugo --printI18nWarnings --minify` but `hugo` is not available in this environment, so no runtime rendering test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9cfb758832ca264d7d903451b51)